### PR TITLE
Add text input playback and audio checks

### DIFF
--- a/background.js
+++ b/background.js
@@ -77,6 +77,11 @@ chrome.runtime.onConnect.addListener(port => {
       if (cfg.apiToken) headers['Authorization'] = 'Bearer ' + cfg.apiToken;
       const body = JSON.stringify({ model: 'tts-1', input: text, voice: cfg.voice, stream: true });
       const res = await fetch(url, { method: 'POST', headers, body });
+      const ctype = res.headers.get('content-type') || '';
+      if (!res.ok || !ctype.includes('audio')) {
+        const errText = await res.text();
+        throw new Error(errText || 'Invalid response');
+      }
       const reader = res.body.getReader();
       while (true) {
         const { done, value } = await reader.read();

--- a/i18n.js
+++ b/i18n.js
@@ -6,6 +6,8 @@ const langUI = {
     key: 'API Key',
     lang: 'Language',
     voice: 'Voice',
+    text: 'Text',
+    play: 'Play Text',
     refresh: 'Refresh Voices',
     save: 'Save',
     switch: '中文'
@@ -17,6 +19,8 @@ const langUI = {
     key: 'API \u5bc6\u94a5',
     lang: '\u8bed\u8a00',
     voice: '\u97f3\u8272',
+    text: '\u6587\u672c',
+    play: '\u64ad\u653e',
     refresh: '\u5237\u65b0\u8bed\u97f3\u5217\u8868',
     save: '\u4fdd\u5b58',
     switch: 'English'
@@ -32,8 +36,12 @@ function applyPopupI18n(lang = getCurrentUILang()) {
   document.querySelector('label[for="api-key"]').textContent = langUI[lang].key;
   document.querySelector('label[for="language-select"]').textContent = langUI[lang].lang;
   document.querySelector('label[for="voice-select"]').textContent = langUI[lang].voice;
+  const textLabel = document.querySelector('label[for="tts-text"]');
+  if (textLabel) textLabel.textContent = langUI[lang].text;
   document.getElementById('read-selection').textContent = langUI[lang].readSelected;
   document.getElementById('read-page').textContent = langUI[lang].readPage;
+  const playBtn = document.getElementById('play-text');
+  if (playBtn) playBtn.textContent = langUI[lang].play;
   const sw = document.getElementById('ui-lang-switch');
   if (sw) sw.textContent = langUI[lang].switch;
 }

--- a/player.js
+++ b/player.js
@@ -158,6 +158,7 @@
           port.disconnect();
         } else if (msg.error) {
           console.error('TTS stream error', msg.error);
+          alert('TTS error: ' + msg.error);
           port.disconnect();
         }
       });

--- a/popup.css
+++ b/popup.css
@@ -20,7 +20,8 @@ body {
     margin-bottom: 2px;
 }
 .field input,
-.field select {
+.field select,
+.field textarea {
     width: 100%;
     box-sizing: border-box;
 }

--- a/popup.html
+++ b/popup.html
@@ -25,6 +25,10 @@
         <label for="voice-select">Voice</label>
         <select id="voice-select"></select>
     </div>
+    <div class="field">
+        <label for="tts-text">Text</label>
+        <textarea id="tts-text" rows="3" style="width:100%;"></textarea>
+    </div>
     <div style="font-size:12px;margin-top:4px;text-align:center;">
         Recommended local service:
         <a href="https://github.com/samni728/Local-TTS-Service" target="_blank">Local-TTS-Service</a>
@@ -32,6 +36,7 @@
     <div class="buttons">
         <button id="read-selection">Read Selected Text</button>
         <button id="read-page">Read Entire Page</button>
+        <button id="play-text">Play Text</button>
     </div>
     <script src="i18n.js"></script>
     <script src="popup.js"></script>

--- a/popup.js
+++ b/popup.js
@@ -5,6 +5,8 @@ const serverInput = document.getElementById('server-url');
 const apiKeyInput = document.getElementById('api-key');
 const langSelect = document.getElementById('language-select');
 const voiceSelect = document.getElementById('voice-select');
+const textInput = document.getElementById('tts-text');
+const playBtn = document.getElementById('play-text');
 const uiSwitch = document.getElementById('ui-lang-switch');
 let currentUILang = getCurrentUILang();
 
@@ -113,6 +115,12 @@ document.getElementById('read-page').addEventListener('click', async () => {
     const text = await capture(tab.id, () => document.body.innerText);
     speakText(text);
 });
+
+if (playBtn) {
+    playBtn.addEventListener('click', () => {
+        speakText(textInput.value);
+    });
+}
 
 chrome.storage.local.get('pendingText').then(data => {
     if (data.pendingText) {


### PR DESCRIPTION
## Summary
- add text input field and Play button in popup
- internationalize the new elements
- handle API errors and check audio content
- alert when audio streaming fails
- style textarea

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6855775488008333b811ce2188ded86a