### PR TITLE
Improve streaming playback and popup UI

### DIFF
--- a/background.js
+++ b/background.js
@@ -27,7 +27,7 @@ async function playOrPrompt(tabId, text) {
     voice: ''
   });
   if (!cfg.apiUrl || !cfg.voice) {
-    chrome.storage.local.set({ pendingText: text || '' }, () => chrome.action.openPopup());
+    chrome.storage.local.set({ pendingText: text || '' }, () => chrome.runtime.openOptionsPage());
     return;
   }
   await chrome.scripting.executeScript({ target: { tabId }, files: ['player.js'] });
@@ -82,6 +82,7 @@ chrome.runtime.onConnect.addListener(port => {
         const errText = await res.text();
         throw new Error(errText || 'Invalid response');
       }
+      port.postMessage({ mime: ctype.split(';')[0] });
       const reader = res.body.getReader();
       while (true) {
         const { done, value } = await reader.read();

--- a/i18n.js
+++ b/i18n.js
@@ -6,8 +6,6 @@ const langUI = {
     key: 'API Key',
     lang: 'Language',
     voice: 'Voice',
-    text: 'Text',
-    play: 'Play Text',
     refresh: 'Refresh Voices',
     save: 'Save',
     switch: '中文'
@@ -19,8 +17,6 @@ const langUI = {
     key: 'API \u5bc6\u94a5',
     lang: '\u8bed\u8a00',
     voice: '\u97f3\u8272',
-    text: '\u6587\u672c',
-    play: '\u64ad\u653e',
     refresh: '\u5237\u65b0\u8bed\u97f3\u5217\u8868',
     save: '\u4fdd\u5b58',
     switch: 'English'
@@ -36,12 +32,8 @@ function applyPopupI18n(lang = getCurrentUILang()) {
   document.querySelector('label[for="api-key"]').textContent = langUI[lang].key;
   document.querySelector('label[for="language-select"]').textContent = langUI[lang].lang;
   document.querySelector('label[for="voice-select"]').textContent = langUI[lang].voice;
-  const textLabel = document.querySelector('label[for="tts-text"]');
-  if (textLabel) textLabel.textContent = langUI[lang].text;
   document.getElementById('read-selection').textContent = langUI[lang].readSelected;
   document.getElementById('read-page').textContent = langUI[lang].readPage;
-  const playBtn = document.getElementById('play-text');
-  if (playBtn) playBtn.textContent = langUI[lang].play;
   const sw = document.getElementById('ui-lang-switch');
   if (sw) sw.textContent = langUI[lang].switch;
 }

--- a/manifest.json
+++ b/manifest.json
@@ -8,6 +8,9 @@
   },
   "permissions": ["storage", "activeTab", "scripting", "contextMenus"],
   "host_permissions": ["http://*/v1/audio/*", "https://*/v1/audio/*"],
+  "content_security_policy": {
+    "extension_pages": "default-src 'self'; connect-src http://* https://*; media-src blob:;"
+  },
   "background": {
     "service_worker": "background.js"
   },

--- a/player.js
+++ b/player.js
@@ -108,61 +108,72 @@
     audio.playbackRate = document.getElementById('tts-speed').value;
     audio.play();
 
-    mediaSource.addEventListener('sourceopen', async () => {
-      const sourceBuffer = mediaSource.addSourceBuffer('audio/mpeg');
-      const queue = [];
-      let streamEnded = false;
+    const queue = [];
+    let sourceBuffer = null;
+    let mimeType = 'audio/mpeg';
+    let streamEnded = false;
 
-      function appendFromQueue() {
-        if (queue.length && !sourceBuffer.updating) {
-          try {
-            sourceBuffer.appendBuffer(queue.shift());
-          } catch (err) {
-            if (err.name === 'QuotaExceededError') {
-              try {
-                const current = audio.currentTime;
-                if (sourceBuffer.buffered.length && current > 30) {
-                  sourceBuffer.remove(0, current - 30);
-                }
-              } catch (e) {}
-              queue.unshift(queue.shift());
-            } else {
-              console.error('appendBuffer failed', err);
-            }
+    function flushQueue() {
+      if (!sourceBuffer || sourceBuffer.updating) return;
+      if (queue.length) {
+        const chunk = queue.shift();
+        try {
+          sourceBuffer.appendBuffer(chunk);
+        } catch (err) {
+          if (err.name === 'QuotaExceededError') {
+            try {
+              const cur = audio.currentTime;
+              if (sourceBuffer.buffered.length && cur > 30) {
+                sourceBuffer.remove(0, cur - 30);
+              }
+            } catch (_) {}
+            queue.unshift(chunk);
+          } else {
+            console.error('appendBuffer failed', err);
+            queue.unshift(chunk);
+            streamEnded = true;
           }
-        }
-        if (streamEnded && queue.length === 0 && !sourceBuffer.updating) {
-          try { mediaSource.endOfStream(); } catch (e) {}
         }
       }
+      if (streamEnded && queue.length === 0 && !sourceBuffer.updating) {
+        try { mediaSource.endOfStream(); } catch (_) {}
+      }
+    }
 
-      sourceBuffer.addEventListener('updateend', () => {
-        // free old buffered data to prevent quota errors
-        try {
-          const current = audio.currentTime;
-          if (sourceBuffer.buffered.length && current > 30) {
-            sourceBuffer.remove(0, current - 30);
-          }
-        } catch (e) {}
-        appendFromQueue();
-      });
-
-      const port = chrome.runtime.connect({ name: 'tts-stream' });
-      port.onMessage.addListener(msg => {
-        if (msg.chunk) {
-          queue.push(new Uint8Array(msg.chunk));
-          appendFromQueue();
-        } else if (msg.done) {
-          streamEnded = true;
-          appendFromQueue();
-          port.disconnect();
-        } else if (msg.error) {
-          console.error('TTS stream error', msg.error);
-          alert('TTS error: ' + msg.error);
-          port.disconnect();
-        }
-      });
-      port.postMessage({ cfg, text });
+    mediaSource.addEventListener('sourceopen', () => {
+      try {
+        sourceBuffer = mediaSource.addSourceBuffer(mimeType);
+        sourceBuffer.mode = 'sequence';
+        sourceBuffer.addEventListener('updateend', () => {
+          flushQueue();
+        });
+        flushQueue();
+      } catch (e) {
+        console.error('addSourceBuffer failed', e);
+        audio.src = '';
+      }
     });
+
+    const port = chrome.runtime.connect({ name: 'tts-stream' });
+    port.onMessage.addListener(msg => {
+      if (msg.mime) {
+        mimeType = msg.mime;
+      } else if (msg.chunk) {
+        queue.push(new Uint8Array(msg.chunk));
+        flushQueue();
+      } else if (msg.done) {
+        streamEnded = true;
+        flushQueue();
+        port.disconnect();
+      } else if (msg.error) {
+        console.error('TTS stream error', msg.error);
+        alert('TTS error: ' + msg.error);
+        streamEnded = true;
+        flushQueue();
+        port.disconnect();
+      }
+    });
+
+    port.postMessage({ cfg, text });
   };
 })();

--- a/popup.css
+++ b/popup.css
@@ -20,8 +20,7 @@ body {
     margin-bottom: 2px;
 }
 .field input,
-.field select,
-.field textarea {
+.field select {
     width: 100%;
     box-sizing: border-box;
 }

--- a/popup.html
+++ b/popup.html
@@ -25,10 +25,6 @@
         <label for="voice-select">Voice</label>
         <select id="voice-select"></select>
     </div>
-    <div class="field">
-        <label for="tts-text">Text</label>
-        <textarea id="tts-text" rows="3" style="width:100%;"></textarea>
-    </div>
     <div style="font-size:12px;margin-top:4px;text-align:center;">
         Recommended local service:
         <a href="https://github.com/samni728/Local-TTS-Service" target="_blank">Local-TTS-Service</a>
@@ -36,7 +32,6 @@
     <div class="buttons">
         <button id="read-selection">Read Selected Text</button>
         <button id="read-page">Read Entire Page</button>
-        <button id="play-text">Play Text</button>
     </div>
     <script src="i18n.js"></script>
     <script src="popup.js"></script>

--- a/popup.js
+++ b/popup.js
@@ -5,8 +5,7 @@ const serverInput = document.getElementById('server-url');
 const apiKeyInput = document.getElementById('api-key');
 const langSelect = document.getElementById('language-select');
 const voiceSelect = document.getElementById('voice-select');
-const textInput = document.getElementById('tts-text');
-const playBtn = document.getElementById('play-text');
+
 const uiSwitch = document.getElementById('ui-lang-switch');
 let currentUILang = getCurrentUILang();
 
@@ -91,7 +90,7 @@ async function capture(tabId, func) {
 async function speakText(text) {
     if (!text) return;
     if (!config.apiUrl || !config.voice) {
-        chrome.action.openPopup();
+        chrome.runtime.openOptionsPage();
         await chrome.storage.local.set({ pendingText: text });
         return;
     }
@@ -115,12 +114,6 @@ document.getElementById('read-page').addEventListener('click', async () => {
     const text = await capture(tab.id, () => document.body.innerText);
     speakText(text);
 });
-
-if (playBtn) {
-    playBtn.addEventListener('click', () => {
-        speakText(textInput.value);
-    });
-}
 
 chrome.storage.local.get('pendingText').then(data => {
     if (data.pendingText) {


### PR DESCRIPTION
## Summary
- support HTTP requests in CSP
- open options page when configs missing
- send stream MIME type to player
- rewrite streaming logic with MediaSource buffer queue
- simplify popup UI and translations

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68557d9ed6a483339e535d7c74854c88