### PR TITLE
Add fallback voice list when server list unavailable

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@
 2. 点击“加载已解压的扩展程序”，选择 `chrome_extension/` 目录。
 3. 在扩展图标的右键菜单或点击弹出页即可朗读网页内容。
 4. 先在扩展的“选项”页面中填写本地服务地址和 API Token。
-5. 如果未选择音色，扩展会自动使用服务返回的第一个音色。
+5. 如果服务未提供 `/v1/audio/all_voices` 接口，插件会使用 OpenAI 默认的几个音色（alloy、echo、fable、onyx、nova、shimmer）。

--- a/options.js
+++ b/options.js
@@ -1,14 +1,25 @@
 let cfg = {};
+const fallbackVoices = [
+  { name: 'alloy', short_name: 'alloy', locale: 'en-US', gender: 'male' },
+  { name: 'echo', short_name: 'echo', locale: 'en-US', gender: 'male' },
+  { name: 'fable', short_name: 'fable', locale: 'en-US', gender: 'female' },
+  { name: 'onyx', short_name: 'onyx', locale: 'en-US', gender: 'male' },
+  { name: 'nova', short_name: 'nova', locale: 'en-US', gender: 'female' },
+  { name: 'shimmer', short_name: 'shimmer', locale: 'en-US', gender: 'female' }
+];
 
 async function fetchVoices(url, token) {
   try {
     const res = await fetch(`${url}/v1/audio/all_voices`, {
       headers: token ? { 'Authorization': 'Bearer ' + token } : {}
     });
-    return await res.json();
+    if (!res.ok) throw new Error('HTTP ' + res.status);
+    const data = await res.json();
+    if (!Array.isArray(data)) throw new Error('invalid response');
+    return data;
   } catch (e) {
-    console.error('Failed to fetch voices', e);
-    return [];
+    console.warn('Failed to fetch voices, using defaults:', e);
+    return fallbackVoices;
   }
 }
 

--- a/popup.js
+++ b/popup.js
@@ -1,5 +1,13 @@
 let config = {};
 let allVoices = [];
+const fallbackVoices = [
+    { name: 'alloy', short_name: 'alloy', locale: 'en-US', gender: 'male' },
+    { name: 'echo', short_name: 'echo', locale: 'en-US', gender: 'male' },
+    { name: 'fable', short_name: 'fable', locale: 'en-US', gender: 'female' },
+    { name: 'onyx', short_name: 'onyx', locale: 'en-US', gender: 'male' },
+    { name: 'nova', short_name: 'nova', locale: 'en-US', gender: 'female' },
+    { name: 'shimmer', short_name: 'shimmer', locale: 'en-US', gender: 'female' }
+];
 
 const serverInput = document.getElementById('server-url');
 const apiKeyInput = document.getElementById('api-key');
@@ -36,14 +44,16 @@ async function fetchVoices() {
         const res = await fetch(`${url}/v1/audio/all_voices`, {
             headers: apiKeyInput.value ? { 'Authorization': 'Bearer ' + apiKeyInput.value } : {}
         });
-        allVoices = await res.json();
-        const locales = [...new Set(allVoices.map(v => v.locale))];
-        langSelect.innerHTML = locales.map(l => `<option value="${l}">${l}</option>`).join('');
+        if (!res.ok) throw new Error('HTTP ' + res.status);
+        const data = await res.json();
+        if (!Array.isArray(data)) throw new Error('invalid response');
+        allVoices = data;
     } catch (e) {
-        console.error('Failed to fetch voices', e);
-        langSelect.innerHTML = '';
-        voiceSelect.innerHTML = '';
+        console.warn('Failed to fetch voices, using defaults:', e);
+        allVoices = fallbackVoices;
     }
+    const locales = [...new Set(allVoices.map(v => v.locale))];
+    langSelect.innerHTML = locales.map(l => `<option value="${l}">${l}</option>`).join('');
 }
 
 function updateVoiceOptions(locale) {


### PR DESCRIPTION
## Summary
- add fallback voices for OpenAI defaults
- handle fetch failures by using fallback voices
- document fallback behavior in README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6856dbc64c8083338c639fc6208a5174